### PR TITLE
Add hoist-non-react-statics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Add hoist-non-react-statics
+
 ## 1.0.2 - 2018-10-26
 
 - [Flow] Fixed types for Flow 0.84.0

--- a/dist/with-observables.cjs.js
+++ b/dist/with-observables.cjs.js
@@ -1,9 +1,12 @@
 'use strict';
 
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var react = require('react');
+var hoistNonReactStatic = _interopDefault(require('hoist-non-react-statics'));
 var from = require('rxjs/observable/from');
 var combineLatest = require('rxjs/observable/combineLatest');
 var map = require('rxjs/operators/map');
-var react = require('react');
 
 function _classCallCheck(instance, Constructor) {
   if (!(instance instanceof Constructor)) {
@@ -217,144 +220,145 @@ var prefetchTimeout = 2000; // ms
 var withObservablesSynchronized = function withObservablesSynchronized(triggerProps, getObservables) {
   var getNewProps = makeGetNewProps(getObservables);
   return function (BaseComponent) {
-    return (
-      /*#__PURE__*/
-      // TODO: This is probably not going to be 100% safe to use under React async mode
-      // Do more research
-      function (_Component) {
-        _inherits(WithObservablesComponent, _Component);
+    // TODO: This is probably not going to be 100% safe to use under React async mode
+    // Do more research
+    var WithObservablesComponent =
+    /*#__PURE__*/
+    function (_Component) {
+      _inherits(WithObservablesComponent, _Component);
 
-        function WithObservablesComponent(props) {
-          var _this;
+      function WithObservablesComponent(props) {
+        var _this;
 
-          _classCallCheck(this, WithObservablesComponent);
+        _classCallCheck(this, WithObservablesComponent);
 
-          _this = _possibleConstructorReturn(this, _getPrototypeOf(WithObservablesComponent).call(this, props));
-          _this._subscription = null;
-          _this._isMounted = false;
-          _this._prefetchTimeout = null;
-          _this._exitedConstructor = false;
-          _this.state = {
+        _this = _possibleConstructorReturn(this, _getPrototypeOf(WithObservablesComponent).call(this, props));
+        _this._subscription = null;
+        _this._isMounted = false;
+        _this._prefetchTimeout = null;
+        _this._exitedConstructor = false;
+        _this.state = {
+          isFetching: true,
+          values: {},
+          triggeredFromProps: getTriggeringProps(props, triggerProps) // The recommended React practice is to subscribe to async sources on `didMount`
+          // Unfortunately, that's slow, because we have an unnecessary empty render even if we
+          // can get first values before render.
+          //
+          // So we're subscribing in constructor, but that's dangerous. We have no guarantee that
+          // the component will actually be mounted (and therefore that `willUnmount` will be called
+          // to safely unsubscribe). So we're setting a safety timeout to avoid leaking memory.
+          // If component is not mounted before timeout, we'll unsubscribe just to be sure.
+          // (If component is mounted after all, just super slow, we'll subscribe again on didMount)
+
+        };
+
+        _this.subscribeWithoutSettingState(_this.props);
+
+        _this._prefetchTimeout = setTimeout(function () {
+          console.warn("withObservables - unsubscribing from source. Leaky component!");
+
+          _this.unsubscribe();
+        }, prefetchTimeout);
+        _this._exitedConstructor = true;
+        return _this;
+      }
+
+      _createClass(WithObservablesComponent, [{
+        key: "componentDidMount",
+        value: function componentDidMount() {
+          this._isMounted = true;
+          this.cancelPrefetchTimeout();
+
+          if (!this._subscription) {
+            console.warn("withObservables - component mounted but no subscription present. Slow component (timed out) or something weird happened! Re-subscribing");
+            var newTriggeringProps = getTriggeringProps(this.props, triggerProps);
+            this.subscribe(this.props, newTriggeringProps);
+          }
+        } // eslint-disable-next-line
+
+      }, {
+        key: "UNSAFE_componentWillReceiveProps",
+        value: function UNSAFE_componentWillReceiveProps(nextProps) {
+          var triggeredFromProps = this.state.triggeredFromProps;
+          var newTriggeringProps = getTriggeringProps(nextProps, triggerProps);
+
+          if (!identicalArrays(triggeredFromProps, newTriggeringProps)) {
+            this.subscribe(nextProps, newTriggeringProps);
+          }
+        }
+      }, {
+        key: "subscribe",
+        value: function subscribe(props, triggeredFromProps) {
+          this.setState({
             isFetching: true,
             values: {},
-            triggeredFromProps: getTriggeringProps(props, triggerProps) // The recommended React practice is to subscribe to async sources on `didMount`
-            // Unfortunately, that's slow, because we have an unnecessary empty render even if we
-            // can get first values before render.
-            //
-            // So we're subscribing in constructor, but that's dangerous. We have no guarantee that
-            // the component will actually be mounted (and therefore that `willUnmount` will be called
-            // to safely unsubscribe). So we're setting a safety timeout to avoid leaking memory.
-            // If component is not mounted before timeout, we'll unsubscribe just to be sure.
-            // (If component is mounted after all, just super slow, we'll subscribe again on didMount)
-
-          };
-
-          _this.subscribeWithoutSettingState(_this.props);
-
-          _this._prefetchTimeout = setTimeout(function () {
-            console.warn("withObservables - unsubscribing from source. Leaky component!");
-
-            _this.unsubscribe();
-          }, prefetchTimeout);
-          _this._exitedConstructor = true;
-          return _this;
+            triggeredFromProps
+          });
+          this.subscribeWithoutSettingState(props);
         }
+      }, {
+        key: "subscribeWithoutSettingState",
+        value: function subscribeWithoutSettingState(props) {
+          var _this2 = this;
 
-        _createClass(WithObservablesComponent, [{
-          key: "componentDidMount",
-          value: function componentDidMount() {
-            this._isMounted = true;
-            this.cancelPrefetchTimeout();
-
-            if (!this._subscription) {
-              console.warn("withObservables - component mounted but no subscription present. Slow component (timed out) or something weird happened! Re-subscribing");
-              var newTriggeringProps = getTriggeringProps(this.props, triggerProps);
-              this.subscribe(this.props, newTriggeringProps);
+          this.unsubscribe();
+          this._subscription = getNewProps(props).subscribe(function (values) {
+            if (_this2._exitedConstructor) {
+              _this2.setState({
+                values,
+                isFetching: false
+              });
+            } else {
+              // Source has called with first values synchronously while we're still in the
+              // constructor. Here, `this.setState` does not work and we must mutate this.state
+              // directly
+              _this2.state.values = values;
+              _this2.state.isFetching = false;
             }
-          } // eslint-disable-next-line
+          }, function (error) {
+            // we need to explicitly log errors from the new observables, or they will get lost
+            // TODO: It can be difficult to trace back the component in which this error originates. We should maybe propagate this as an error of the component? Or at least show in the error a reference to the component, or the original `getProps` function?
+            console.error("Error in Rx composition in withObservables()", error);
+          });
+        }
+      }, {
+        key: "unsubscribe",
+        value: function unsubscribe() {
+          this._subscription && this._subscription.unsubscribe();
+          this.cancelPrefetchTimeout();
+        }
+      }, {
+        key: "cancelPrefetchTimeout",
+        value: function cancelPrefetchTimeout() {
+          this._prefetchTimeout && clearTimeout(this._prefetchTimeout);
+          this._prefetchTimeout = null;
+        }
+      }, {
+        key: "shouldComponentUpdate",
+        value: function shouldComponentUpdate(nextProps, nextState) {
+          // If one of the triggering props change but we don't yet have first values from the new
+          // observable, *don't* render anything!
+          return !nextState.isFetching;
+        }
+      }, {
+        key: "componentWillUnmount",
+        value: function componentWillUnmount() {
+          this.unsubscribe();
+        }
+      }, {
+        key: "render",
+        value: function render() {
+          var _this$state = this.state,
+              isFetching = _this$state.isFetching,
+              values = _this$state.values;
+          return isFetching ? null : react.createElement(BaseComponent, _objectSpread({}, this.props, values));
+        }
+      }]);
 
-        }, {
-          key: "UNSAFE_componentWillReceiveProps",
-          value: function UNSAFE_componentWillReceiveProps(nextProps) {
-            var triggeredFromProps = this.state.triggeredFromProps;
-            var newTriggeringProps = getTriggeringProps(nextProps, triggerProps);
+      return WithObservablesComponent;
+    }(react.Component);
 
-            if (!identicalArrays(triggeredFromProps, newTriggeringProps)) {
-              this.subscribe(nextProps, newTriggeringProps);
-            }
-          }
-        }, {
-          key: "subscribe",
-          value: function subscribe(props, triggeredFromProps) {
-            this.setState({
-              isFetching: true,
-              values: {},
-              triggeredFromProps
-            });
-            this.subscribeWithoutSettingState(props);
-          }
-        }, {
-          key: "subscribeWithoutSettingState",
-          value: function subscribeWithoutSettingState(props) {
-            var _this2 = this;
-
-            this.unsubscribe();
-            this._subscription = getNewProps(props).subscribe(function (values) {
-              if (_this2._exitedConstructor) {
-                _this2.setState({
-                  values,
-                  isFetching: false
-                });
-              } else {
-                // Source has called with first values synchronously while we're still in the
-                // constructor. Here, `this.setState` does not work and we must mutate this.state
-                // directly
-                _this2.state.values = values;
-                _this2.state.isFetching = false;
-              }
-            }, function (error) {
-              // we need to explicitly log errors from the new observables, or they will get lost
-              // TODO: It can be difficult to trace back the component in which this error originates. We should maybe propagate this as an error of the component? Or at least show in the error a reference to the component, or the original `getProps` function?
-              console.error("Error in Rx composition in withObservables()", error);
-            });
-          }
-        }, {
-          key: "unsubscribe",
-          value: function unsubscribe() {
-            this._subscription && this._subscription.unsubscribe();
-            this.cancelPrefetchTimeout();
-          }
-        }, {
-          key: "cancelPrefetchTimeout",
-          value: function cancelPrefetchTimeout() {
-            this._prefetchTimeout && clearTimeout(this._prefetchTimeout);
-            this._prefetchTimeout = null;
-          }
-        }, {
-          key: "shouldComponentUpdate",
-          value: function shouldComponentUpdate(nextProps, nextState) {
-            // If one of the triggering props change but we don't yet have first values from the new
-            // observable, *don't* render anything!
-            return !nextState.isFetching;
-          }
-        }, {
-          key: "componentWillUnmount",
-          value: function componentWillUnmount() {
-            this.unsubscribe();
-          }
-        }, {
-          key: "render",
-          value: function render() {
-            var _this$state = this.state,
-                isFetching = _this$state.isFetching,
-                values = _this$state.values;
-            return isFetching ? null : react.createElement(BaseComponent, _objectSpread({}, this.props, values));
-          }
-        }]);
-
-        return WithObservablesComponent;
-      }(react.Component)
-    );
+    return hoistNonReactStatic(WithObservablesComponent, BaseComponent);
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "url": "https://github.com/Nozbe/withObservables.git"
   },
   "dependencies": {
+    "hoist-non-react-statics": "^3.3.0",
     "rxjs": "^6.2.2"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
 
 import type { Observable, Subscription } from 'rxjs'
 import { Component, createElement } from 'react'
+import hoistNonReactStatic from 'hoist-non-react-statics'
 
 import combineLatestObject from './combineLatestObject'
 import mapObject from './mapObject'
@@ -84,7 +85,7 @@ const withObservablesSynchronized = <PropsInput: {}, ObservableProps: {}>(
     triggeredFromProps: any[],
   }
 
-  return BaseComponent =>
+  return BaseComponent => {
     // TODO: This is probably not going to be 100% safe to use under React async mode
     // Do more research
     class WithObservablesComponent extends Component<*, State> {
@@ -207,6 +208,9 @@ const withObservablesSynchronized = <PropsInput: {}, ObservableProps: {}>(
         return isFetching ? null : createElement(BaseComponent, { ...this.props, ...values })
       }
     }
+
+    return hoistNonReactStatic(WithObservablesComponent, BaseComponent)
+  }
 }
 
 export default withObservablesSynchronized

--- a/yarn.lock
+++ b/yarn.lock
@@ -2043,6 +2043,13 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -3601,6 +3608,11 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-is@^16.7.0:
+  version "16.8.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.2.tgz#09891d324cad1cb0c1f2d91f70a71a4bee34df0f"
+  integrity sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q==
 
 read-pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
There's a lot of React libs that uses custom statics to work, like react-native-navigation.
This PR fixes them.

For example, react-native-navigation [uses `static options` to implement layout](https://wix.github.io/react-native-navigation/#/docs/topBar-buttons?id=declaring-buttons-statically):
```js
class MyScreen extends Component {
  static options(passProps) {
    return {
      topBar: {
        leftButtons: [
          {
            id: 'buttonOne',
            icon: require('icon.png')
          }
        ],
        rightButtons: [],
      }
    };
  }
}
```

Without this PR, `static options` will be ignored and will show a blank topBar :(