### PR TITLE
Optimizations - Part 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- Improve performance slightly
+- Improve performance
 - Name functions for easier debugging / profiling
 
 ## 1.0.5 - 2019-08-10

--- a/dist/with-observables.esm.js
+++ b/dist/with-observables.esm.js
@@ -64,6 +64,42 @@ var mapObject = function mapObject(fn, obj) {
   return willReturn;
 };
 
+var cleanUpBatchingInterval = 250; // ms
+
+var cleanUpInterval = 2000; // ms
+
+var pendingCleanupActions = [];
+var scheduledCleanUpScheduler = null;
+
+function cleanUpWithObservablesActions(actions) {
+  actions.forEach(function (action) {
+    return action();
+  });
+}
+
+function scheduleCleanUp() {
+  scheduledCleanUpScheduler = null;
+  var actions = pendingCleanupActions.slice(0);
+  pendingCleanupActions = [];
+  setTimeout(function () {
+    cleanUpWithObservablesActions(actions);
+  }, cleanUpInterval);
+} // Apparently, setTimeout/clearTimeout functions are very expensive (22 microseconds/call)
+// And we must schedule a cleanup / garbage collection action
+// (https://github.com/facebook/react/issues/15317#issuecomment-491269433)
+// The workaround is this: all cleanup actions scheduled within a 250ms window will be scheduled
+// together (for 2500ms later).
+// This way, all actions within that window will only call setTimeout twice
+
+
+function scheduleForCleanup(fn) {
+  pendingCleanupActions.push(fn);
+
+  if (!scheduledCleanUpScheduler) {
+    scheduledCleanUpScheduler = setTimeout(scheduleCleanUp, cleanUpBatchingInterval);
+  }
+}
+
 var toObservable = function toObservable(value) {
   return typeof value.observe === 'function' ? value.observe() : value;
 };
@@ -101,11 +137,9 @@ function getTriggeringProps(props, propNames) {
   return propNames.map(function (name) {
     return props[name];
   });
-}
-
-var prefetchTimeout = 2000; // ms
-// TODO: This is probably not going to be 100% safe to use under React async mode
+} // TODO: This is probably not going to be 100% safe to use under React async mode
 // Do more research
+
 
 var WithObservablesComponent =
 /*#__PURE__*/
@@ -118,7 +152,7 @@ function (_Component) {
     _this = _Component.call(this, props) || this;
     _this._subscription = null;
     _this._isMounted = false;
-    _this._prefetchTimeout = null;
+    _this._prefetchTimeoutCanceled = false;
     _this._exitedConstructor = false;
     _this.BaseComponent = BaseComponent;
     _this.triggerProps = triggerProps;
@@ -139,11 +173,13 @@ function (_Component) {
 
     _this.subscribeWithoutSettingState(_this.props);
 
-    _this._prefetchTimeout = setTimeout(function () {
-      console.warn("withObservables - unsubscribing from source. Leaky component!");
+    scheduleForCleanup(function () {
+      if (!_this._prefetchTimeoutCanceled) {
+        console.warn("withObservables - unsubscribing from source. Leaky component!");
 
-      _this.unsubscribe();
-    }, prefetchTimeout);
+        _this.unsubscribe();
+      }
+    });
     _this._exitedConstructor = true;
     return _this;
   }
@@ -215,8 +251,7 @@ function (_Component) {
   };
 
   _proto.cancelPrefetchTimeout = function cancelPrefetchTimeout() {
-    this._prefetchTimeout && clearTimeout(this._prefetchTimeout);
-    this._prefetchTimeout = null;
+    this._prefetchTimeoutCanceled = true;
   };
 
   _proto.shouldComponentUpdate = function shouldComponentUpdate(nextProps, nextState) {

--- a/src/garbageCollector.js
+++ b/src/garbageCollector.js
@@ -1,0 +1,34 @@
+// @flow
+
+const cleanUpBatchingInterval = 250 // ms
+const cleanUpInterval = 2000 // ms
+
+let pendingCleanupActions: Array<() => void> = []
+let scheduledCleanUpScheduler: ?TimeoutID = null
+
+function cleanUpWithObservablesActions(actions: Array<() => void>): void {
+  actions.forEach(action => action())
+}
+
+function scheduleCleanUp(): void {
+  scheduledCleanUpScheduler = null
+  const actions = pendingCleanupActions.slice(0)
+  pendingCleanupActions = []
+  setTimeout(() => {
+    cleanUpWithObservablesActions(actions)
+  }, cleanUpInterval)
+}
+
+// Apparently, setTimeout/clearTimeout functions are very expensive (22 microseconds/call)
+// But we must schedule a cleanup / garbage collection action
+// (https://github.com/facebook/react/issues/15317#issuecomment-491269433)
+// The workaround is this: all cleanup actions scheduled within a 250ms window will be scheduled
+// together (for 2500ms later).
+// This way, all actions within that window will only call setTimeout twice
+export default function scheduleForCleanup(fn: () => void): void {
+  pendingCleanupActions.push(fn)
+
+  if (!scheduledCleanUpScheduler) {
+    scheduledCleanUpScheduler = setTimeout(scheduleCleanUp, cleanUpBatchingInterval)
+  }
+}


### PR DESCRIPTION
Huh. So apparently, setTimeout/clearTimeout functions are very expensive (22 microseconds/call). I measured 7ms wasted (7% of the "seems instantaneous" budget!) on setTimeout/clearTimeout on Chrome. (I wonder if that has something to do with browsers' Spectre/Meltdown mitigations).

I consulted the way mobx-react-lite implemented a solution to garbage collection: https://github.com/mobxjs/mobx-react-lite/blob/avoid-leaks-in-reaction-cleanup/src/reactionCleanupTracking.ts @RoystonS @FredyC — it's good and probably better, but this seemed good enough, and easier to implement.