### PR TITLE
fix: Unable to resolve module `rxjs-compat/operators/map`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.3.0",
-    "rxjs": "^6.4.0"
+    "rxjs": "^6.6.3",
+    "rxjs-compat": "^6.6.3"
   },
   "peerDependencies": {
     "react": "^16.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4054,10 +4054,22 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+rxjs-compat@^6.6.3:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs-compat/-/rxjs-compat-6.6.3.tgz#141405fcee11f48718d428b99c8f01826f594e5c"
+  integrity sha512-y+wUqq7bS2dG+7rH2fNMoxsDiJ32RQzFxZQE/JdtpnmEZmwLQrb1tCiItyHxdXJHXjmHnnzFscn3b6PEmORGKw==
+
 rxjs@^6.4.0, rxjs@^6.5.2:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
   integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.3:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
this commit solves the problem with the inclusion of lib rxjs-compat as a project dependency

In addition, I did a "MINOR" update in rxjs. 

This [doc](https://github.com/ReactiveX/rxjs/blob/473a66813c841ee2763eac186d0ac47ea1737815/docs_app/content/guide/v6/migration.md#rxjs-v5x-to-v6-update-guide) shows that the use of lib rxjs-compat is very important for the correct functioning of lib.
