### PR TITLE
fix(package): resolve failed type deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "url": "https://github.com/Nozbe/withObservables.git"
   },
   "dependencies": {
+    "@types/hoist-non-react-statics": "^3.3.1",
     "hoist-non-react-statics": "^3.3.2",
     "rxjs": "^6.6.3",
     "rxjs-compat": "^6.6.3"
   },
   "peerDependencies": {
-    "@types/hoist-non-react-statics": "^3.3.1",
     "@types/react": "^16.9.23",
     "react": "^16.4.2"
   },
@@ -64,7 +64,6 @@
     "@babel/plugin-transform-template-literals": "^7.2.0",
     "@babel/runtime": "^7.3.4",
     "@nozbe/watermelondb": "^0.16.2",
-    "@types/hoist-non-react-statics": "^3.3.1",
     "@types/react": "^16.9.23",
     "babel-core": "^7.0.0-0",
     "babel-eslint": "10.0.3",


### PR DESCRIPTION
I was running into an issue where enhancing a component would always result in an `any` type.  However, the types in the example (`__tests__/typescript/typescript.test.tsx`) seemed to work perfectly as expected. After some debugging I realized that my project seemed to have problems referencing [`hoist-non-react-statics` in `@nozbe/with-observables/index.d.ts`](https://github.com/Nozbe/withObservables/blob/88f056184d00ac9e4deb4fd315d1858bae0e3b4b/index.d.ts#L64)-- moving `@types/hoist-non-react-statics` to the main dependencies and forcing it to install seems to fix my issues.

CC: @azizhk would appreciate a review, thanks!