### PR TITLE
Update peerDependencies to support React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   },
   "peerDependencies": {
     "@types/hoist-non-react-statics": "^3.3.1",
-    "@types/react": "^16.9.23",
-    "react": "^16.4.2"
+    "@types/react": "^16.9.23||^17",
+    "react": "^16.4.2||^17"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
WatermelonDB and withObservables work fine with React 17. 

React 17 doesn’t bring breaking changes that should affect this project.