### PR TITLE
Bump package.json peer depedencies to support rn ^.79

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "peerDependencies": {
     "@types/hoist-non-react-statics": "^3.3.1",
-    "@types/react": "^16||^17||^18",
-    "react": "^16||^17||^18"
+    "@types/react": "^16||^17||^18||^19",
+    "react": "^16||^17||^18||^19"
   },
   "peerDependenciesMeta": {
     "@types/hoist-non-react-statics": {


### PR DESCRIPTION
Fix the current npm error for newer users:

npm error
npm error Conflicting peer dependency: @types/react@18.3.20 npm error node_modules/@types/react
npm error   peerOptional @types/react@"^16||^17||^18" from @nozbe/with-observables@1.6.0
npm error   node_modules/@nozbe/with-observables
npm error     @nozbe/with-observables@"^1.6.0" from the root project
npm error